### PR TITLE
Update alsa-modular-synth.desktop

### DIFF
--- a/alsa-modular-synth.desktop
+++ b/alsa-modular-synth.desktop
@@ -2,7 +2,7 @@
 Name=ALSA Modular Synth
 Comment=Modular soft syntheziter
 Comment[pl]=Programowy syntezator modularny
-Exec=ams --presetpath=/usr/share/ams
+Exec=ams --presetdir=/usr/share/ams
 Terminal=false
 Type=Application
 Categories=Qt;Audio;


### PR DESCRIPTION
Line 5 is uses an non-existent named param --presetpath. This causes AMS to ignore the path to the preset file if it is specified.
The fix is to use the correct --presetdir param:
Exec=ams --presetdir=/usr/share/ams